### PR TITLE
Updating patchset for 4.1.x kernel as used by my buildroot config

### DIFF
--- a/03_enable_leds.patch
+++ b/03_enable_leds.patch
@@ -1039,18 +1039,6 @@ diff -urN linux-4.0.1/drivers/leds/Makefile linux-4.0.1-wd1/drivers/leds/Makefil
  # LED SPI Drivers
  obj-$(CONFIG_LEDS_DAC124S085)		+= leds-dac124s085.o
  
-diff -urN linux-4.0.1/fs/ext4/mballoc.c linux-4.0.1-wd1/fs/ext4/mballoc.c
---- linux-4.0.1/fs/ext4/mballoc.c	2015-04-29 11:22:30.000000000 +0300
-+++ linux-4.0.1-wd1/fs/ext4/mballoc.c	2015-05-02 22:19:57.702639194 +0300
-@@ -668,7 +668,7 @@
- 	ext4_grpblk_t min;
- 	ext4_grpblk_t max;
- 	ext4_grpblk_t chunk;
--	unsigned short border;
-+	unsigned int border;
- 
- 	BUG_ON(len > EXT4_CLUSTERS_PER_GROUP(sb));
- 
 diff -urN linux-4.0.1/include/linux/leds.h linux-4.0.1-wd1/include/linux/leds.h
 --- linux-4.0.1/include/linux/leds.h	2015-04-29 11:22:30.000000000 +0300
 +++ linux-4.0.1-wd1/include/linux/leds.h	2015-05-02 17:35:27.099690732 +0300

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
-# kernel-4.0.x
+# kernel-4.1.x
 My Book Live patches for vanilla Linux kernel
+
+Tested with LTS linux-4.1.39 at https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-4.1.39.tar.xz


### PR DESCRIPTION
It looks like there are only minimal changes needed to get these patches merged to an LTS version (4.1.x). I'm testing these changes against 4.1.40 now.